### PR TITLE
Networking & Other Refactoring

### DIFF
--- a/core/network/src/peer/inbound.rs
+++ b/core/network/src/peer/inbound.rs
@@ -1,6 +1,6 @@
 use std::{
     io::{self, Error, ErrorKind},
-    net::{IpAddr, SocketAddr},
+    net::SocketAddr,
     sync::Arc,
 };
 
@@ -34,7 +34,7 @@ impl Listener {
             .with_single_cert(vec![certificate], private_key)
             .map_err(|e| {
                 Error::new(
-                    ErrorKind::InvalidInput,
+                    ErrorKind::Other,
                     format!("failed to create TLS server config '{}'", e),
                 )
             })?;
@@ -46,11 +46,9 @@ impl Listener {
 
     /// Creates a listening stream for the specified IP and port.
     /// ref. <https://github.com/rustls/hyper-rustls/blob/main/examples/server.rs>
-    pub fn listen(&self, ip: IpAddr, port: u16) -> io::Result<Stream> {
-        log::info!("[rustls] listening on {}:{}", ip, port);
+    pub fn listen(&self, addr: SocketAddr) -> io::Result<Stream> {
+        log::info!("[rustls] listening on {addr}");
 
-        // ref. https://doc.rust-lang.org/std/net/enum.SocketAddr.html
-        let addr = SocketAddr::new(ip, port);
         let incoming = AddrIncoming::bind(&addr)
             .map_err(|e| Error::new(ErrorKind::Other, format!("failed to bind '{}'", e)))?;
         let local_addr = incoming.local_addr();

--- a/core/network/src/peer/outbound.rs
+++ b/core/network/src/peer/outbound.rs
@@ -1,4 +1,4 @@
-use std::net;
+use std::net::SocketAddr;
 use std::{
     io::{self, Error, ErrorKind, Read, Write},
     net::TcpStream,
@@ -51,70 +51,55 @@ impl Connector {
 
     /// Creates a connection to the specified peer's IP and port.
     /// ref. <https://pkg.go.dev/github.com/ava-labs/avalanchego/network/peer#NewTLSClientUpgrader>
-    pub fn connect(
-        &self,
-        peer_ip: net::IpAddr,
-        port: u16,
-        _timeout: Duration,
-    ) -> io::Result<Stream> {
-        info!("[rustls] connecting to {}:{}", peer_ip, port);
+    pub fn connect(&self, addr: SocketAddr, _timeout: Duration) -> io::Result<Stream> {
+        info!("[rustls] connecting to {addr}");
 
-        // ref. https://doc.rust-lang.org/std/net/enum.SocketAddr.html
-        let sock_addr = format!("{}:{}", peer_ip, port);
-
-        // This is now possible with rustls v0.21.0+
-        let server_name: ServerName = ServerName::try_from(peer_ip.to_string().as_ref()).unwrap();
+        let server_name = ServerName::IpAddress(addr.ip());
         let mut conn =
             rustls::ClientConnection::new(self.client_config.clone(), server_name).unwrap();
-        let mut sock = TcpStream::connect(sock_addr.clone()).unwrap();
+        let mut sock = TcpStream::connect(addr).unwrap();
         let mut tls = rustls::Stream::new(&mut conn, &mut sock);
 
-        let binding = format!("GET / HTTP/1.1\r\nHost: {}:{}\r\nConnection: close\r\nAccept-Encoding: identity\r\n\r\n", peer_ip, port);
-        let header = binding.as_bytes();
+        let binding = format!("GET / HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\nAccept-Encoding: identity\r\n\r\n");
+
         // This is a dummy write to ensure that the certificate data is transmitted.
         // Without this GET we get an error: Error: Custom { kind: NotConnected, error: "no peer certificate found" }
-        match tls.write_all(header) {
-            Ok(_) => {
-                println!("\n\n WROTE REQUEST\n\n");
-            }
-            Err(e) => {
-                println!("failed to write request: {}", e);
-            }
-        };
+        tls.write_all(binding.as_bytes())?;
+        info!("\n\n WROTE REQUEST\n\n");
 
         info!("retrieving peer certificates...");
-        let peer_certs = conn.peer_certificates();
-        if peer_certs.is_none() {
-            return Err(Error::new(
-                ErrorKind::NotConnected,
-                "no peer certificate found",
-            ));
-        }
 
         // The certificate details are used to establish node identity.
         // See https://docs.avax.network/specs/cryptographic-primitives#tls-certificates.
         // The avalanchego certs are intentionally NOT signed by a legitimate CA.
-        let peer_certs = peer_certs.unwrap();
-        let peer_certificate = peer_certs[0].clone();
+        let (peer_certificate, other_certificates) = conn
+            .peer_certificates()
+            .and_then(|certs| certs.split_first())
+            .ok_or(Error::new(
+                ErrorKind::NotConnected,
+                "no peer certificate found",
+            ))?;
+
         let peer_node_id = node::Id::from_cert_der_bytes(&peer_certificate.0)?;
         info!(
             "successfully connected to {} (total {} certificates, first cert {}-byte)",
             peer_node_id,
-            peer_certs.len(),
+            other_certificates.len() + 1,
             peer_certificate.0.len(),
         );
 
         Ok(Stream {
-            addr: sock_addr,
-            conn,
+            addr,
             peer_certificate: peer_certificate.clone(),
             peer_node_id,
 
             #[cfg(feature = "pem_encoding")]
             peer_certificate_pem: pem::encode(&Pem::new(
                 "CERTIFICATE".to_string(),
-                peer_certificate.0,
+                peer_certificate.0.clone(),
             )),
+
+            conn,
         })
     }
 }
@@ -153,7 +138,7 @@ fn test_connector() {
 /// Represents a connection to a peer.
 /// ref. <https://github.com/rustls/rustls/commit/b8024301747fb0328c9493d7cf7268e0de17ffb3>
 pub struct Stream {
-    pub addr: String,
+    pub addr: SocketAddr,
 
     /// ref. <https://docs.rs/rustls/latest/rustls/enum.Connection.html>
     /// ref. <https://docs.rs/rustls/latest/rustls/client/struct.ClientConnection.html>

--- a/crates/avalanche-types/src/message/version.rs
+++ b/crates/avalanche-types/src/message/version.rs
@@ -71,13 +71,13 @@ impl Message {
     }
 
     #[must_use]
-    pub fn tracked_subnets(mut self, tracked_subnets: Vec<ids::Id>) -> Self {
-        let mut tracked_subnet_bytes: Vec<prost::bytes::Bytes> =
-            Vec::with_capacity(tracked_subnets.len());
-        for id in tracked_subnets.iter() {
-            tracked_subnet_bytes.push(prost::bytes::Bytes::from(id.to_vec()));
-        }
-        self.msg.tracked_subnets = tracked_subnet_bytes;
+    pub fn tracked_subnets(mut self, tracked_subnets: impl AsRef<[ids::Id]>) -> Self {
+        self.msg.tracked_subnets = tracked_subnets
+            .as_ref()
+            .iter()
+            .map(|id| id.to_vec())
+            .map(prost::bytes::Bytes::from)
+            .collect();
         self
     }
 
@@ -180,7 +180,7 @@ fn test_message() {
         .my_version(String::from("v1.2.3"))
         .my_version_time(1234567)
         .sig(random_manager::secure_bytes(65).unwrap())
-        .tracked_subnets(vec![
+        .tracked_subnets([
             ids::Id::empty(),
             ids::Id::empty(),
             ids::Id::empty(),

--- a/tests/avalanchego-byzantine/src/tests/mod.rs
+++ b/tests/avalanchego-byzantine/src/tests/mod.rs
@@ -1,6 +1,5 @@
 use std::{
-    net::{IpAddr, Ipv4Addr},
-    str::FromStr,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
     thread,
     time::{Duration, Instant, SystemTime},
 };
@@ -269,8 +268,7 @@ async fn byzantine() {
         utils::urls::extract_scheme_host_port_path_chain_alias(&rpc_eps[0]).unwrap();
     log::info!("connecting to the first peer {} with port {:?}", host, port);
     let res = connector.connect(
-        IpAddr::from_str("127.0.0.1").unwrap(),
-        port.unwrap(),
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port.unwrap()),
         Duration::from_secs(10),
     );
     if res.is_err() {


### PR DESCRIPTION
Some of the bigger improves are:
- Replacing manually parsing localhost ip with LOCALHOST constant
- `array::from_fn` to avoid duplication when generating random IDs
- Make functions which have paramaters for `ip: IpAddr, port: u16` instead have `SocketAddr`
- Having `Message::tracked_subnets` accept any slice instead of just Vecs (overly strict type for what is needed)
- Change TLS server/client config error to be consistently `io::error::ErrorKind::Other`